### PR TITLE
auto-pot-based-on-users-threshold

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -413,7 +413,7 @@ server:
     PLAYERNPC_AUTODEPLOY: true      #Makes PlayerNPC automatically deployed on the Hall of Fame at the instant one reaches max level. If false, eligible players must talk to 1st job instructor to deploy a NPC.
 
     #Pet Auto-Pot Configuration
-    USE_COMPULSORY_AUTOPOT: false    #Pets will consume as many potions as needed to fulfill the AUTOHP/MP ratio threshold.
+    USE_COMPULSORY_AUTOPOT: false    #This controlls wheter the auto HP/MP Pot % Threshold is controlled via server (Globally via PET_AUTOHP_RATIO / PET_AUTOMP_RATIO  ) or user's settings
     USE_EQUIPS_ON_AUTOPOT: true     #Player MaxHP and MaxMP check values on autopot handler will be updated by the HP/MP bonuses on equipped items.
     PET_AUTOHP_RATIO: 0.99          #Will automatically consume potions until given ratio of the MaxHP/MaxMP is reached.
     PET_AUTOMP_RATIO: 0.99

--- a/src/client/processor/action/PetAutopotProcessor.java
+++ b/src/client/processor/action/PetAutopotProcessor.java
@@ -144,7 +144,26 @@ public class PetAutopotProcessor {
                             qtyCount = 0;
                         }
                     } else {
-                        qtyCount = 1;   // non-compulsory autopot concept thanks to marcuswoon
+                            // use hp / mana pots based on user's config
+                        float autohpAlert = chr.getAutopotHpAlert();
+                        float autompAlert = chr.getAutopotMpAlert();
+                        if (hasHpGain) {
+                            double hpRatio = (autohpAlert * maxHp) - curHp;
+                            if (hpRatio > 0.0) {
+                                qtyCount = (int) Math.ceil(hpRatio / incHp);
+                            }
+                        }
+
+                        if (hasMpGain) {
+                            double mpRatio = ((autompAlert * maxMp) - curMp);
+                            if (mpRatio > 0.0) {
+                                qtyCount = Math.max(qtyCount, (int) Math.ceil(mpRatio / incMp));
+                            }
+                        }
+
+                        if (qtyCount < 0) {
+                            qtyCount = 0;
+                        }
                     }
 
                     while (true) {


### PR DESCRIPTION
use of getAutopotHpAlert to get the threshold that the user wanted  and then healing them up to that point instead of using 1 pot.